### PR TITLE
Add runnable Launch4J launcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This repository only contains a starting template. Many features would need to b
 
 ```
 ./gradlew build
-./gradlew launch4j # generates RaspberryClient.exe in build/launcher
+./gradlew launch4j   # generates RaspberryClient.exe and the jar in build/launcher
 ```
 
 The build requires internet access to download dependencies.

--- a/build.gradle
+++ b/build.gradle
@@ -35,13 +35,27 @@ application {
     mainClass = 'com.raspberryclient.launcher.RaspberryLauncher'
 }
 
+// Windows launcher configuration using Launch4J. The jar used by the EXE is
+// copied next to the launcher so the application can be distributed as a
+// simple folder containing RaspberryClient.exe and the client jar.
 launch4j {
     outputDir = "$buildDir/launcher"
     outfile = 'RaspberryClient.exe'
     mainClassName = application.mainClass
-    jar = "$buildDir/libs/${project.name}-${version}.jar"
+    // The jar path is relative to the generated EXE. We copy the jar in a
+    // separate task before running Launch4J.
+    jar = "${project.name}-${version}.jar"
     jreMinVersion = '1.8.0'
 }
+
+// Copy the client jar next to the generated launcher so the EXE can find it.
+task copyJarForLaunch(type: Copy) {
+    from("$buildDir/libs/${project.name}-${version}.jar")
+    into("$buildDir/launcher")
+}
+
+// Ensure the jar is present before creating the launcher.
+launch4j.dependsOn(copyJarForLaunch)
 
 jar {
     manifest.attributes('Main-Class': application.mainClass)

--- a/src/main/java/com/raspberryclient/launcher/RaspberryLauncher.java
+++ b/src/main/java/com/raspberryclient/launcher/RaspberryLauncher.java
@@ -3,6 +3,9 @@ package com.raspberryclient.launcher;
 import javax.swing.JButton;
 import javax.swing.JFrame;
 import java.io.File;
+import java.net.URISyntaxException;
+
+import com.raspberryclient.mod.RaspberryClient;
 
 /**
  * Simple launcher that wraps the built jar and starts it with Java.
@@ -13,7 +16,19 @@ public class RaspberryLauncher {
         JButton play = new JButton("Play");
         play.addActionListener(e -> {
             try {
-                File jar = new File("RaspberryClient-1.0.0.jar");
+                // Determine the directory this launcher is running from so the
+                // client jar can be located next to the EXE or jar.
+                File base;
+                try {
+                    base = new File(RaspberryLauncher.class.getProtectionDomain()
+                            .getCodeSource().getLocation().toURI()).getParentFile();
+                } catch (URISyntaxException ex) {
+                    base = new File(".");
+                }
+
+                String jarName = String.format("%s-%s.jar", "RaspberryClient", RaspberryClient.VERSION);
+                File jar = new File(base, jarName);
+
                 ProcessBuilder pb = new ProcessBuilder("java", "-jar", jar.getAbsolutePath());
                 pb.inheritIO();
                 pb.start();


### PR DESCRIPTION
## Summary
- configure Launch4J to copy the jar next to the generated EXE
- update RaspberryLauncher to locate the jar relative to its own path
- document build instructions

## Testing
- `gradle tasks --all` *(fails: Could not resolve net.minecraftforge.gradle:ForgeGradle:2.3-SNAPSHOT)*

------
https://chatgpt.com/codex/tasks/task_e_685ddeeb4878832298fe54a1d12913c5